### PR TITLE
Add Github Action to test on all compatible Node versions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,42 @@
+name: CI
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+  - cron: 0 0 * * 0
+
+jobs:
+  test:
+    name: Test
+
+    strategy:
+      matrix:
+        node: [20.x]
+        os: [ubuntu-latest]
+        include:
+        - node: 19.x
+          os: ubuntu-latest
+        - node: 18.x
+          os: ubuntu-latest
+
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Install Node.js ${{ matrix.node }}
+      uses: actions/setup-node@v4
+      with: { node-version: "${{ matrix.node }}" }
+    - name: Install Packages
+      run: npm install
+    - name: Test
+      run: npm run -s test -- --reporters="jest-junit" --reporters=default
+    - name: Test Report
+      uses: dorny/test-reporter@v1
+      if: success() || failure()
+      with:
+        name: Tests Results (${{ matrix.node }})
+        path: junit.xml
+        reporter: jest-junit

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,20 @@
 {
   "name": "stylelint-formatter-gitlab-code-quality-report",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stylelint-formatter-gitlab-code-quality-report",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "jest": "^29.7.0",
+        "jest-junit": "^16.0.0",
         "standard": "^17.1.0"
       },
       "engines": {
-        "node": ">=20.10.0"
+        "node": ">=18.12.0"
       },
       "peerDependencies": {
         "stylelint": ">=16.0.0"
@@ -5823,6 +5824,42 @@
         "fsevents": "^2.3.2"
       }
     },
+    "node_modules/jest-junit": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-16.0.0.tgz",
+      "integrity": "sha512-A94mmw6NfJab4Fg/BlvVOUXzXgF0XIH6EmTgJ5NDPp4xoKq0Kr7sErb+4Xs9nZvu58pJojz5RFGpqnZYJTrRfQ==",
+      "dev": true,
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "strip-ansi": "^6.0.1",
+        "uuid": "^8.3.2",
+        "xml": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/jest-junit/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-junit/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jest-leak-detector": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
@@ -7241,6 +7278,18 @@
       "peer": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ms": {
@@ -9054,6 +9103,15 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "peer": true
     },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
@@ -9325,6 +9383,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+      "dev": true
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "type": "module",
   "engines": {
-    "node": ">=20.10.0"
+    "node": ">=18.12.0"
   },
   "keywords": [
     "stylelint",
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "jest": "^29.7.0",
+    "jest-junit": "^16.0.0",
     "standard": "^17.1.0"
   }
 }


### PR DESCRIPTION
Fix #1

Adds GitHub Action CI to test all Node versions.

Results sample: https://github.com/ben12/stylelint-formatter-gitlab-code-quality-report/actions/runs/7850183414